### PR TITLE
AG-808: Bump data manifest version to 46 for distribution data fix

### DIFF
--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,5 +1,5 @@
 {
-    "data-version": "45",
+    "data-version": "46",
     "data-manifest-id": "syn13363290",
     "team-images-id": "syn12861877"
 }

--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,5 +1,5 @@
 {
-    "data-version": "43",
+    "data-version": "45",
     "data-manifest-id": "syn13363290",
     "team-images-id": "syn12861877"
 }


### PR DESCRIPTION
bump to manifest v46 to pick up distribution data sort fix (AG-827/AG-829) for 3.0.1 release