### PR TITLE
AG-1158: Import and index new biodomain_info collection

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -51,6 +51,12 @@ const collections = [
         indexes: [
             { ensembl_gene_id: 1 }
         ]
+    },
+    {
+        name: 'biodomaininfo',
+        indexes: [
+            { name: 1 }
+        ]
     }
 ];
 

--- a/import-data.sh
+++ b/import-data.sh
@@ -62,6 +62,7 @@ mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabas
 mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection proteomicsboxdistribution --jsonArray --drop --file $DATA_DIR/proteomics_distribution_data.json
 mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection proteomicstmt --jsonArray --drop --file $DATA_DIR/proteomics_tmt.json
 mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection genesbiodomains --jsonArray --drop --file $DATA_DIR/genes_biodomains.json
+mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection biodomaininfo --jsonArray --drop --file $DATA_DIR/biodomain_info.json
 
 mongo --host $DB_HOST -u $DB_USER -p $DB_PASS --authenticationDatabase admin $WORKING_DIR/create-indexes.js
 


### PR DESCRIPTION
This PR updates the data population scripts used for our AWS enviornments to:
* import the new biodomain_info file
* index the new biodomaininfo collection

We will merge this during our working meeting today.
Additional info: https://sagebionetworks.jira.com/wiki/spaces/AGORA/pages/2525921321/Importing+data+into+Agora+AWS+databases