### PR TITLE
[IT-3964] Update mongo command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,9 +6,6 @@ on:
   push:
     branches: ['develop', 'staging', 'prod' ]
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/import-data.sh
+++ b/import-data.sh
@@ -65,7 +65,7 @@ mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabas
 mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection genesbiodomains --jsonArray --drop --file $DATA_DIR/genes_biodomains.json
 mongoimport -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase admin --collection biodomaininfo --jsonArray --drop --file $DATA_DIR/biodomain_info.json
 
-mongo --host $DB_HOST -u $DB_USER -p $DB_PASS --authenticationDatabase admin $WORKING_DIR/create-indexes.js
+mongosh --host $DB_HOST -u $DB_USER -p $DB_PASS --authenticationDatabase admin $WORKING_DIR/create-indexes.js
 
 pushd $TEAM_IMAGES_DIR
 ls -1r *.{jpg,jpeg,png} | while read x; do mongofiles -h $DB_HOST -d agora -u $DB_USER -p $DB_PASS --authenticationDatabase $DB_USER -v put $x; echo $x; done


### PR DESCRIPTION
We have updated our Github self hosted runners to use the latest versions of the MongoDB tools.

```
mongodb-database-tools.x86_64                                     100.10.0-1                                  @mongodb-org-8.0
mongodb-mongosh-shared-openssl3.x86_64                            2.3.6-1.el8                                 @mongodb-org-8.0
```

MongoDB changed the name of their mongo cli command to "mongosh" therefore we need to update accordingly.

[1] https://www.mongodb.com/blog/post/introducing-the-new-shell


depends on https://github.com/Sage-Bionetworks/agora2-infra/pull/30