### PR TITLE
AG-1640: align key with name expected by sage-monorepo

### DIFF
--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,5 +1,5 @@
 {
     "data_version": "71",
-    "data_manifest_id": "syn13363290",
+    "data_file": "syn13363290",
     "team_images_id": "syn12861877"
 }

--- a/import-data.sh
+++ b/import-data.sh
@@ -20,12 +20,12 @@ mkdir -p $TEAM_IMAGES_DIR
 
 # Version key/value should be on his own line
 DATA_VERSION=$(cat $WORKING_DIR/data-manifest.json | grep data_version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
-DATA_MANIFEST_ID=$(cat $WORKING_DIR/data-manifest.json | grep data_manifest_id | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
+DATA_FILE=$(cat $WORKING_DIR/data-manifest.json | grep data_file | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
 TEAM_IMAGES_ID=$(cat $WORKING_DIR/data-manifest.json | grep team_images_id | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
-echo "$BRANCH branch, DATA_VERSION = $DATA_VERSION, manifest id = $DATA_MANIFEST_ID"
+echo "$BRANCH branch, DATA_VERSION = $DATA_VERSION, manifest id = $DATA_FILE"
 
 # Download the manifest file from synapse
-synapse -p $SYNAPSE_PASSWORD get --downloadLocation $DATA_DIR -v $DATA_VERSION $DATA_MANIFEST_ID
+synapse -p $SYNAPSE_PASSWORD get --downloadLocation $DATA_DIR -v $DATA_VERSION $DATA_FILE
 
 # Ensure there's a newline at the end of the manifest file; otherwise the last listed file will not be downloaded
 # echo >> $DATA_DIR/data_manifest.csv


### PR DESCRIPTION
## Description

The new Agora site shows `undefined` in the Data Version -- 

<img width="199" alt="image" src="https://github.com/user-attachments/assets/50d6632b-9d09-45d1-bc29-acf7a7e3e7d9" />

We need to update `data-manifest.json` to use `data_file` instead of `data_manifest_id`, so the key matches the name expected by Agora.