### PR TITLE
AG-1819: Bump data version to mv73

### DIFF
--- a/data-manifest.json
+++ b/data-manifest.json
@@ -1,5 +1,5 @@
 {
-    "data_version": "72",
+    "data_version": "73",
     "data_file": "syn13363290",
     "team_images_id": "syn12861877"
 }


### PR DESCRIPTION
This PR will deploy mv73 to the dev environment.

mv73 includes a new version of gene_info containing the 2025 TREAT-AD target nominations.
