### PR TITLE
AG-1886: add index to gene_info.alias to improve search performance, fix field name of existing index

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -10,7 +10,8 @@ const collections = [
         indexes: [
             { ensembl_gene_id: 1, hgnc_symbol: 1 },
             { hgnc_symbol: 1 },
-            { nominations: -1, hgnc_symbol: 1 }
+            { alias: 1 },
+            { target_nominations: -1, hgnc_symbol: 1 }
         ]
     },
     {


### PR DESCRIPTION
## Description

Updates Agora `gene_info` collection indexes to include `alias` to improve search performance. See [AG-1886](https://sagebionetworks.jira.com/browse/AG-1886). 

Also fixes field name of an existing index (`nominations` -> `target_nominations`) in the `gene_info` collection.

[AG-1886]: https://sagebionetworks.jira.com/browse/AG-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ