### PR TITLE
AG-1886: fix indexed field

### DIFF
--- a/create-indexes.js
+++ b/create-indexes.js
@@ -11,7 +11,7 @@ const collections = [
             { ensembl_gene_id: 1, hgnc_symbol: 1 },
             { hgnc_symbol: 1 },
             { alias: 1 },
-            { target_nominations: -1, hgnc_symbol: 1 }
+            { total_nominations: -1, hgnc_symbol: 1 }
         ]
     },
     {


### PR DESCRIPTION
The index was changed to `target_nominations` instead of `total_nominations`, which resulted in [an error](https://github.com/Sage-Bionetworks/agora-data-manager/actions/runs/18175093888/job/51739011397) when attempting to deploy: `MongoServerError: key too large to index. Index name: target_nominations_-1_hgnc_symbol_1`. Update to the correct field.