### PR TITLE
AG-1893: Add missing hypen to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ is executed on the self-hosted runner with the `develop` label, which in turn up
 
 ### Setup self hosted runners
 
-Github self hosted runners are deployed with [Cloudformation](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/blob/dev/src/bastion_stack.py).
+Github self-hosted runners are deployed with [Cloudformation](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/blob/dev/src/bastion_stack.py).
 
 Self Hosted Runner setup:
 * Deploy the template to the Agora AWS account.


### PR DESCRIPTION
This very important update is necessary to re-trigger a failed staging deployment.
